### PR TITLE
Fix infinite loop where `vertical-motion` skips invisible chars

### DIFF
--- a/quick-peek.el
+++ b/quick-peek.el
@@ -93,10 +93,12 @@
     (goto-char pos)
     (let ((line-move-visual 1)
           (win-start (window-start nil))
-          (available-lines (window-body-height)))
-      (while (> (point) win-start)
-        (vertical-motion -1)
-        (cl-decf available-lines))
+          (available-lines (window-body-height))
+          (moved t))
+      (while (and moved (> (point) win-start))
+        (setq moved (not (zerop (vertical-motion -1))))
+        (when moved
+          (cl-decf available-lines)))
       available-lines)))
 
 (defun quick-peek--text-width (from to)


### PR DESCRIPTION
From `vertical-motion`s documentation:

    If LINES is zero, point will move to the first visible character on
    the current screen line.

If the first character of the buffer is currently invisible but the line itself is visible cursor will end up after `win-start` and because of this the while loop will never terminate.

This commit adds a simple check to prevent that.

---

Rarely happens but I have `org-modern` enabled and that hides characters like `#+` from the beginning of lines which causes this issue to appear if I am using `quick-peek` and the top of the buffer is visible and the buffer starts with `#+` (or any other characters that are invisible)